### PR TITLE
added chirp2025 proceedings and chirp2024 metadata

### DIFF
--- a/proceedings/chirp2025/index.html
+++ b/proceedings/chirp2025/index.html
@@ -1,0 +1,298 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta http-equiv="Content-type" content="text/html;charset=utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" type="text/css" href="../ceur-ws.css">
+  <title>Proceedings of the CHIRP 2024: Transforming HCI Research in the Philippines Workshop</title>
+
+  <!-- Volume-level metadata for Google Scholar -->
+  <meta name="citation_conference_title" content="CHIRP 2024: Transforming HCI Research in the Philippines Workshop">
+  <meta name="citation_publication_date" content="2024/05/09">
+  <meta name="citation_editor" content="Briane Paul V. Samson">
+  <meta name="citation_editor" content="Jordan Aiko Deja">
+  <meta name="citation_editor" content="Toni-Jan Keith Monserrat">
+
+</head>
+<!--CEURLANG=eng -->
+
+<body>
+  <!-- <pre> -->
+  <!-- # Editing instructions
+# The following variables need to be adapted by you:
+# JJJJ=Year in which the final papers of the proceedings were produced 
+# YYYY=Year in which the workshop took place (in most cases YYYY=JJJJ)
+# NNNN=Acronym of the Workshop 
+# DD=Day of submission of the workshop proceedings to CEUR-WS.org
+# MM=Month of submission of the workshop proceedings (MM=01,02,03,04,05,06,07,08,09,10,11,12)
+# The variable 
+# XXX=Volume number of the proceedings with CEUR-WS.org
+# shall be set by CEUR-WS.org. CEUR-WS.org shall also set the publication date.
+#
+#
+# (*) Replace title of the workshop in the title element 
+# (*) Replace title of the workshop in the heading h1 element 
+# (*) Note that the style file ceur-ws.css and the image CEUR-WS-logo.png are referring to files within
+#     the CEUR-WS.org web site; they are not part of the submission directory
+# (*) Remove lines starting with #  or &lt;pre&gt;# when preparing the file index.html
+# 
+# Some elements are tagged with a "class=CEUR..." clause. Be careful to maintain these tags!
+# They are used both for formatting purposes and for identifying bibliographic elements.
+# The CEUR class tags are as follows:
+#          CEURLANG: the main language of the proceedings (eng, deu, fra, spa, rus, ita, por, ...)
+#                 according to ISO 639-2/T (http://en.wikipedia.org/wiki/List_of_ISO_639-2_codes)
+#          CEURVOLNR: the volume number of the proceedings **set by us**
+#          CEURPUBYEAR: the year in which the proceedings volume was created (see also YYYY)
+#          CEURURN: the URN of the volume **set by us**
+#          CEURVOLACRONYM: the acronym of the workshop plus YYYY (year of the workshop)
+#                 the acronym may contain '-'; between acronym and year is either a blank
+#                 or a '-'. The year is exactly 4 digits, e.g. 2012
+#          CEURVOLTITLE: the title of the proceedings
+#          CEURFULLTITLE: the long title of the proceedings
+#          CEURCOLOCATED: the acronym and year of the conference where this workshop was 
+#              co-located with; use "NONE" if the workshop was not co-located with a conference
+#          CEURLOCTIME: the place and time when the workshop took place
+#          CEURVOLEDITOR: full name of an editor of the proceedings
+#          CEURTOC: indicator for the start of the table of contents
+#          CEURSESSION (optional): separator for a section within the table of contents
+#          title: title of a paper within the table of contents
+#          pages (optional): numerical range of pages of a paper, e.g. 10-20
+#          author: one author of a paper (use full names, do not include affiliations);
+#                 multiple authors should be separated by commas
+#          CEURPUBDATE: the precise date of publication at CEUR-WS.org **set by us**
+#          CEURSUBMITTEDPAPERS: the total number of papers submitted for peer review to this volume
+#          CEURACCEPTEDPAPERS: the total number of accepted peer-reviewed papers (excl. invited papers, keynotes etc)
+#          CEURACCEPTEDREGULARPAPERS: the number of regular-size accepted peer-reviewed papers (optional)
+#          CEURACCEPTEDSHORTPAPERS: the number of short accepted peer-reviewed papers  (optional)
+#          
+#</pre> -->
+
+
+
+  <table style="border: 0; border-spacing: 0; border-collapse: collapse; width: 95%">
+    <tbody>
+      <tr>
+        <td style="text-align: left; vertical-align: middle">
+          <a href="https://sigchimnl.org/chirp/chirp2024">
+            <div id="LOGO"></div>
+          </a>
+        </td>
+        <td style="text-align: right; vertical-align: middle">
+          <div style="float:left" id="CCBY"></div>
+          <span class="VOLNR">Vol-XXX</span> <br>
+          <span class="URN">urn:nbn:de:0074-XXX-C</span>
+          <p class="unobtrusive copyright" style="text-align: justify">Copyright &copy; 2024 for
+            the individual papers by the papers' authors.
+            Copyright &copy; <span class="PUBYEAR">2024</span> for the volume
+            as a collection by its editors.
+            This volume and its papers are published under the
+            Creative Commons License Attribution 4.0 International
+            <A HREF="https://creativecommons.org/licenses/by/4.0/">(<span class="LIC">CC BY 4.0</span>)</A>.
+          </p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <hr>
+  <!-- <pre>
+    
+    # Instructions for the Proceedings Title 
+# The layout of the proceedings title can be adapted to your needs.
+# Make sure to include all proceedings editors and their affiliations. 
+# Links to home pages are fine but not required. Some workshops have
+# a special logo. This could be included here provided that you own the
+# copyright to the logo. Do NOT include logos of companies, products, 
+# or sponsors.
+#</pre> -->
+
+  <br><br><br>
+
+  <h1><a href="https://sigchimnl.org/chirp/chirp2024/"><span class="VOLACRONYM">CHIRP 2024</span></a><br>
+    <span class="VOLTITLE">Transforming HCI Research in the Philippines Workshop</span>
+  </h1>
+  <br>
+
+  <h3>
+    <span class="FULLTITLE">Proceedings of CHIRP 2024: Transforming HCI Research in the Philippines Workshop</span><br>
+    <!-- <pre># delete one of the following two CEURCOLOCATED lines:</pre> -->
+    <!-- co-located with <span class="CEURCOLOCATED">NONE</span> -->
+    <!-- co-located with 10th International Conference on Online Publishing (<span class="CEURCOLOCATED">OPub
+      YYYY</span>)<br> -->
+  </h3>
+  <h3><span class="LOCTIME">Binan, Laguna, May 9, 2024</span>.</h3>
+  <!-- <pre># If the event is virtual, then specify "Virtual Event, City, Country ..." using the location of the local organizer of the event</pre> -->
+
+  <br>
+  <b> Edited by </b>
+  <p>
+
+    <!-- <pre># use full names, but omit any academic title</pre> -->
+  </p>
+  <h3>
+    <a href="https://www.brianesamson.com/"><span class="VOLEDITOR">Briane Paul V. Samson</span></a> *<br>
+
+    <a href="https://jrdndj.notion.site"> <span class="VOLEDITOR">Jordan Aiko Deja</span></a> *<br>
+
+    <a href="https://www.linkedin.com/in/tjmonsi/?originalSubdomain=ph"> <span class="VOLEDITOR">Toni-Jan Keith Monserrat</span></a> **<br>
+
+    <!-- <a href="http://www.personal-webpage.org/myhome/"><span class="CEURVOLEDITOR">Mary Editor</span></a> *<br>
+    <span class="CEURVOLEDITOR">Peter Coeditor</span> **<br> -->
+
+  </h3>
+
+  * <a href="https://www.dlsu.edu.ph">De La Salle University</a>,
+  College of Computer Studies, Manila, Philippines <br>
+  ** <a href="https://www.senti.ai">Senti AI</a>, Manila, Philippines<br>
+  <br>
+
+  <hr>
+
+  <br><br><br>
+
+  <!-- <pre># Instructions for Table of Contents 
+# The table of contents normally is a plain list of papers (with titles/authors).
+# The paper title should be linked to the paper URL (usually pdf).
+# You may include "session" subsections e.g. to reflect the track structure of your workshop.
+# Authors should be specified as comma-separated lists with full author names
+# (like John Smith). Avoid glue words like 'by' and 'and'. If applicable, then lookup how
+# the author is spelled out by DBLP.
+# You may also provide additional material such as preface, bibtex files, complete 
+# proceedings as a single pdf, and similar items. The additional items should be 
+# clearly separated from the paper list, preferably after the table of contents.
+# Please only tag original papers with the title/author scheme. Rather do not tag
+# additional material with this scheme!
+# For the time being, presentation slides should also not be tagged by title/author.
+#
+# CEUR-WS shall watermark PDF files in a published volume by its online CEUR-WS.org URL.
+# If there are certain PDF files like frontmatter or images that you like to exclude
+# from watermarking, then give it a name like 'xfrontmatter.pdf'. 
+#
+# For all other PDF files, use functional names like
+#   - paper1.pdf   (regular papers; start with paper1, then paper2,...)
+#   - invited1.pdf  (invited paper)
+#   - keynote1.pdf  (a variant for invited papers)
+#   - short1.pdf   (a short paper that still is a citable paper)
+#   - abstract1.pdf  (an abstract that is not supposed to be a citable paper)
+#   - preface.pdf   (a preface, usually not citable)
+# By default, all PDF files of a published volume will be watermarked by their online CEUR-WS URL.
+# You can disable this by prefixing the filename with the letter 'x', see xpreface below.
+#</pre> -->
+
+
+  <div class="TOC">
+    <h2> Table of Contents </h2>
+
+    <!-- <pre># Prefaces, frontmatter etc. typically have no explicit authors.
+# Note that the &lt;li id="..."&gt; attribute should have the same value as
+# the name of the file linked to, just without the filename extension.
+# This allows the table of contents entries to be linked to.
+# If a preface has explicit authors and has the nature of a paper with
+# more than 4-5 pages and a list of references, then use the CEUR tags like
+# for regular papers.
+# Please provide a summary sentence about the number of submitted and accepted papers. You can explain the peer-review
+# process in more detail in the preface pdf file. You can change the precise wording of the sentence to adapt it to
+# the context of your workshop/conference. The tags for REGULAR and SHORT papers are optional.
+# </pre> -->
+    <ul>
+      <li id="preface">
+        <A href="preface.pdf">Preface</A><BR>
+        Summary: There were <span class="SUBMITTEDPAPERS">15</span> papers submitted for peer-review to this
+        workshop. Out of these,
+        <span class="ACCEPTEDPAPERS">8</span> papers were accepted for this volume,
+        <span class="ACCEPTEDREGULARPAPERS">7</span> as regular papers and
+        <span class="ACCEPTEDSHORTPAPERS">1</span> as short paper.
+      </li>
+    </ul>
+    <BR>
+    <h3><span class="SESSION">Research Papers</span></h3>
+
+    <ul>
+      <li id="paper2"> <a href="Papers/paper2.html">
+          <span class="title">Alexa, I wanna see you: Envisioning Smart Home Assistants for the Deaf and Hard-of-Hearing</span></a>
+        <span class="pages">1-6</span><br>
+        <span class="author">Tyrone Justin R Sta. Maria</span>,
+        <span class="author">Jordan Aiko Deja</span>
+      </li>
+
+      <li id="paper3"><a href="Papers/paper3.html">
+          <span class="title">Expanded Envisoning: AI-Enabled Design Futuring for Filipino Early Career Researchers in HCI</span></a>
+        <span class="pages">7-22</span><br>
+        <span class="author">Bianca Mikaila V Aguilar</span>
+      </li>
+
+      <li id="paper4"><a href="Papers/paper4.html">
+          <span class="title">Xtra Rice: Opportunities for Social VR as a Reflective Medium in Navigating the Filipino Identity</span></a>
+        <span class="pages">23-32</span><br>
+        <span class="author">Richard Lance Parayno</span>
+      </li>
+
+      <li id="paper5"><a href="Papers/paper5.html">
+          <span class="title">Exploring Design Opportunities for Improved Self-motivation in Self-tracking and Health Goal Achievement</span></a>
+        <span class="pages">33-40</span><br>
+        <span class="author">Elyssia Barrie H Ong</span>,
+        <span class="author">Briane Paul Samson</span>
+      </li>
+
+      <li id="paper6"><a href="Papers/paper6.html">
+          <span class="title">Exploring the Importance of Notification Design on User Engagement</span></a>
+        <span class="pages">41-49</span><br>
+        <span class="author">Hans Matthew Abello</span>,
+        <span class="author">Maxine Beatriz Badiola</span>,
+        <span class="author">Mark John Custer</span>,
+        <span class="author">Lorane Bernadeth Fausto</span>,
+        <span class="author">Patrick Josh Leonida</span>,
+        <span class="author">Denzel Bryan R Yongco</span>,
+        <span class="author">Jordan Aiko Deja</span>
+      </li>
+
+      <li id="paper12"><a href="Papers/paper12.html">
+          <span class="title">Point n Move: Designing a Glove-Based Pointing Device</span></a>
+        <span class="pages">49-58</span><br>
+        <span class="author">Sealtiel B Dy</span>,
+        <span class="author">Robert Joachim O Encinas</span>,
+        <span class="author"> Daphne Janelyn L Go</span>,
+        <span class="author">Kyle Carlo C Lasala</span>,
+        <span class="author">Bentley Andrew Y Lu</span>,
+        <span class="author">Maria Monica Manlises</span>,
+        <span class="author">Jordan Aiko Deja</span>
+      </li>
+
+       <li id="paper13"><a href="Papers/paper13.html">
+          <span class="title">That Flick is Sick: Gyroscope Integration in Xbox Controllers</span></a>
+             <span class="pages">59-69</span><br>
+        <span class="author">Jhervey Edric Cheng</span>,
+        <span class="author">Stacy Selena Kalaw</span>,
+        <span class="author">James Patrick Jo Kok</span>,
+        <span class="author">Alyssa Ysabelle Meneses</span>,
+        <span class="author">Richard Sy</span>,
+        <span class="author">Jordan Aiko Deja</span>
+      </li>
+
+       <li id="paper14"><a href="Papers/paper14.html">
+          <span class="title">How Fitts' Fits in 3D: A Tangible Twist on Spatial Tasks</span></a>
+        <span class="pages">70-79</span><br>
+        <span class="author">Faith Griffin</span>,
+        <span class="author">Kevin Abelgas</span>,
+        <span class="author">Kriz Royce Tahimic</span>,
+        <span class="author">Andrei Kevin Chua</span>,
+        <span class="author">Jordan Aiko Deja</span>,
+        <span class="author">Tyrone Justin Sta. Maria</span>
+      </li>
+    </ul>
+
+
+  </div>
+
+
+  <hr>
+  <span class="unobtrusive">
+    2024-12-20: submitted by Jordan Aiko Deja, Briane Paul Samson,
+    metadata incl. bibliographic data published under <A
+      HREF="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0</A><br>
+    <span >2024-12-29</span>: published on CHIRP Workshop Proceedings (sigchimnl.org/chirp/chirp2024/, ISSN TBA)
+  </span>
+</body>
+
+</html>


### PR DESCRIPTION
# CHANGE LOG

## CHIRP 2024
- updated index.html to include google scholar meta data for indexing
- instead of each paper directly linking to pdf (eg. paper2.pdf), added per-page html that links to pdf (eg. paper2.html). 
- added all per-papaer html and linked to each paper pdf so should be no issues. 

## CHIRP 2025
- followed the updated format with google scholar metadata indexing and added css 


# Needed from Webchair
- update CHIRP 2025 to include proceedings (add menu item as well)
- update SIGCHI MNL to list both CHIRP 2024 and CHIRP 2025 workshop events in the menu 

Thank you so much 